### PR TITLE
chore(ci): add wiki auto-update workflow on PR merge

### DIFF
--- a/.github/workflows/wiki-update.yml
+++ b/.github/workflows/wiki-update.yml
@@ -1,0 +1,86 @@
+name: Update Wiki on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  update-wiki:
+    name: Update Wiki
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Clone wiki
+        run: |
+          git clone \
+            "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" \
+            wiki
+        continue-on-error: true
+
+      - name: Init wiki if clone failed
+        run: |
+          if [ ! -d wiki ]; then
+            mkdir wiki
+            cd wiki
+            git init
+            git checkout -b master
+          fi
+
+      - name: Update wiki with PR context
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: --model claude-sonnet-4-6 --max-turns 8
+          direct_prompt: |
+            Update the GitHub wiki for this repository to reflect the changes
+            introduced by the merged PR.
+
+            PR number: ${{ github.event.pull_request.number }}
+            PR title: ${{ github.event.pull_request.title }}
+            PR body: ${{ github.event.pull_request.body }}
+            Author: ${{ github.event.pull_request.user.login }}
+
+            Wiki directory: ./wiki/
+            Repo root: ./
+
+            Instructions:
+            1. Read the merged PR diff using git diff to understand what changed
+            2. Read each wiki file: wiki/Home.md, wiki/User-Guide.md,
+               wiki/Setup-Guide.md, wiki/Technical-Reference.md
+            3. Update ONLY the sections that are affected by this PR:
+               - New feature or behaviour → User-Guide.md: features + usage
+               - New env variable or config → Setup-Guide.md: environment variables table
+               - New dependency → Technical-Reference.md: dependencies table
+               - Architecture change → Technical-Reference.md: architecture section
+               - New API route or HA entity → Technical-Reference.md: API surface
+               - Breaking change → Setup-Guide.md: add migration note
+            4. Do NOT rewrite, restructure, or rename any wiki pages
+            5. Do NOT modify sections unrelated to this PR's changes
+            6. On every page you modify, update the footer line to:
+               "Last updated: PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
+            7. Write all changes directly to files in the ./wiki/ directory
+
+      - name: Commit and push wiki
+        run: |
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No wiki changes needed for this PR"
+          else
+            git commit -m "docs(wiki): update from PR #${{ github.event.pull_request.number }}
+
+            ${{ github.event.pull_request.title }}"
+            git push origin master 2>/dev/null || git push origin main 2>/dev/null
+            echo "Wiki updated successfully"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Wiki auto-update workflow on PR merge
 - Claude Code workflow configuration with GitHub Actions CI pipelines
 - CodeRabbit review integration with assertive profile
 - PR templates for standard, bug, and chore pull requests


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically updates the wiki pages when PRs are merged. Uses Claude to identify which sections need updating based on the PR diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Added GitHub Actions workflow for automatic wiki updates**: A new workflow (`.github/workflows/wiki-update.yml`) that triggers when pull requests are merged to `main`. The workflow:
  - Clones or initializes the repository wiki
  - Uses Claude (via `anthropics/claude-code-action@v1`) to analyze the PR diff and identify which wiki sections are affected
  - Updates only the affected sections in wiki files (User-Guide.md, Setup-Guide.md, Technical-Reference.md)
  - Updates footer lines on modified pages with PR number and title
  - Commits and pushes changes back to the wiki repository
  - Maps PR changes to specific wiki updates: new features → User-Guide, environment variables → Setup-Guide, architecture changes → Technical-Reference

- **Updated CHANGELOG**: Added entry under `[Unreleased] → Added` for "Wiki auto-update workflow on PR merge"

## Why

Automates wiki documentation maintenance to keep it synchronized with code changes after each PR merge, reducing manual documentation updates and ensuring documentation stays current.

## Breaking Changes

None

## Files Changed

| File | Lines Added | Lines Removed |
|------|-------------|---------------|
| `.github/workflows/wiki-update.yml` | 86 | 0 |
| `CHANGELOG.md` | 1 | 0 |
| **Total** | **87** | **0** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->